### PR TITLE
fix manual sensitivity #501

### DIFF
--- a/cava.c
+++ b/cava.c
@@ -879,13 +879,13 @@ as of 0.4.0 all options are specified in config file, see in '/home/username/.co
                 pthread_mutex_unlock(&audio.lock);
 
                 for (int n = 0; n < (number_of_bars / output_channels) * audio_channels; n++) {
-                    if (p.autosens) {
-                        if (output_mode != OUTPUT_SDL_GLSL) {
-                            cava_out[n] *= *dimension_value;
-                        }
-                    } else {
-                        // cava_out[n] *= p.sens;
+
+                    if (output_mode != OUTPUT_SDL_GLSL) {
+                        cava_out[n] *= *dimension_value;
                     }
+
+                    cava_out[n] *= p.sens;
+
                     if (output_mode == OUTPUT_SDL_GLSL) {
                         if (cava_out[n] > 1.0)
                             cava_out[n] = 1.0;

--- a/cavacore.c
+++ b/cavacore.c
@@ -82,11 +82,10 @@ struct cava_plan *cava_init(int number_of_bars, unsigned int rate, int channels,
     p->rate = rate;
     p->autosens = 1;
     p->sens_init = 1;
-    p->sens = 1;
+    p->sens = 1.0;
     p->autosens = autosens;
     p->framerate = 75;
     p->frame_skip = 1;
-    p->average_max = 0;
     p->noise_reduction = noise_reduction;
 
     p->FFTbassbufferSize = treble_buffer_size * 8;
@@ -462,14 +461,9 @@ void cava_execute(double *cava_in, int new_samples, double *cava_out, struct cav
     }
 
     // applying sens or getting max value
-    for (int n = 0; n < p->number_of_bars * p->audio_channels; n++) {
-        if (p->autosens) {
+    if (p->autosens) {
+        for (int n = 0; n < p->number_of_bars * p->audio_channels; n++) {
             cava_out[n] *= p->sens;
-        } else {
-            if (cava_out[n] > p->average_max) {
-                p->average_max -= p->average_max / 64;
-                p->average_max += cava_out[n] / 64;
-            }
         }
     }
     // process [smoothing]

--- a/cavacore.h
+++ b/cavacore.h
@@ -48,7 +48,6 @@ struct cava_plan {
 
     double sens;
     double framerate;
-    double average_max;
     double noise_reduction;
 
     fftw_plan p_bass_l, p_bass_r;


### PR DESCRIPTION
this was accidentally removed in fb40732

references to average max removed, was not used. do not rememeber what it was for.