### PR TITLE
update libcava library version string

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -238,7 +238,7 @@ install_headers(h_O_files, subdir: 'cava/output')
 pkg = import('pkgconfig')
 pkg.generate(libraries: cava_lib,
              subdirs: ['cava', 'cava/input', 'cava/output'],
-             version: '0.8.5',
+             version: '0.9.1',
              name: 'libcava',
              filebase: 'cava',
              description: 'A cava library')


### PR DESCRIPTION
Hi LukashonakV, I updated the version string of the libcava library to 0.9.1. This is requied to build waybar in version 0.9.23 (it requires the libcava library at least in version 0.9.1).