### PR TITLE
Fix build compilation errors with new iniparser 4.2.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,9 +65,15 @@ endif
 
 ### Iniparser
 iniparser_dep = cc.find_library('iniparser', has_headers: 'iniparser.h', required: false)
+
+if not iniparser_dep.found()
+   iniparser_dep = cc.find_library('iniparser', has_headers: 'iniparser/iniparser.h', required: false)
+endif
+
 if not iniparser_dep.found()
    iniparser_dep = cc.find_library('iniparser4', has_headers: 'iniparser4/iniparser.h', required: false)
 endif
+
 if not iniparser_dep.found()
    error('iniparser library is required')
 else

--- a/src/config.c
+++ b/src/config.c
@@ -6,6 +6,8 @@
 #ifndef _MSC_VER
 #if __has_include(<iniparser.h>)
 #include <iniparser.h>
+#elif __has_include(<iniparser/iniparser.h>)
+#include <iniparser/iniparser.h>
 #elif __has_include(<iniparser4/iniparser.h>)
 #include <iniparser4/iniparser.h>
 #endif


### PR DESCRIPTION
Compilation fails now that `iniparser` headers is now `/usr/include/iniparser/iniparser.h`

Seems like someone had a similar issue from an older PR: https://github.com/LukashonakV/cava/pull/15.
This should also fix https://github.com/Alexays/Waybar/issues/3288.